### PR TITLE
Fix getRecordOrigin & getRecordURL in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -380,8 +380,8 @@ record.getIndexedAt()    // => 1511913554723
 
 Every record is emitted in a wrapper object with the following methods:
 
- - `getURL()` The URL of the record.
- - `getOrigin()` The URL of the site the record was found on.
+ - `getRecordURL()` The URL of the record.
+ - `getRecordOrigin()` The URL of the site the record was found on.
  - `getIndexedAt()` The timestamp of when the record was indexed.
 
 These attributes can be used in indexes with the following IDs:


### PR DESCRIPTION
Tiny fix: `getRecordOrigin` & `getRecordURL` are incorrectly called `getOrigin` and `getURL` in the "Record methods" section.